### PR TITLE
ember-vo-mu-file-upload fix

### DIFF
--- a/app/components/poi-picture-manipulator.hbs
+++ b/app/components/poi-picture-manipulator.hbs
@@ -64,5 +64,5 @@
 </div>
 
 <div class="au-o-box au-o-box--small">
-  <AuFileUpload @onFinishUpload={{this.uploadedFile}} @maxFileSizeMB="1024" @multiple={{true}} />
+  <AuFileUpload @endPoint="/file-service/files" @onFinishUpload={{this.uploadedFile}} @maxFileSizeMB="1024" @multiple={{true}} />
 </div>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
     "@lblod/ember-acmidm-login": "^1.1.1",
+    "@lblod/ember-vo-mu-file-upload": "0.7.0",
     "@types/ember": "^3.16.4",
     "@types/ember-data": "^3.16.12",
     "@types/ember-data__model": "^3.16.2",
@@ -104,6 +105,5 @@
     "edition": "octane"
   },
   "dependencies": {
-    "@lblod/ember-vo-mu-file-upload": "git://github.com/lblod/ember-vo-mu-file-upload.git#master"
   }
 }


### PR DESCRIPTION
since the default endpoint changed '/files' this change should hopefully make this work with the latest version (not tested)